### PR TITLE
Update ListModuleController - correct deprecated locallang_reference

### DIFF
--- a/Classes/Controller/ListModuleController.php
+++ b/Classes/Controller/ListModuleController.php
@@ -136,7 +136,7 @@ class ListModuleController extends ActionController
         $newWindowButton = GeneralUtility::makeInstance(ExtendedLinkButton::class);
         $newWindowButton->setIcon($newWindowIcon)
                 ->setTarget('_blank')
-                ->setTitle(LocalizationUtility::translate('LLL:EXT:lang/locallang_core.xlf:labels.openInNewWindow', 'lang'))
+                ->setTitle(LocalizationUtility::translate('LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.openInNewWindow', 'lang'))
                 ->setHref(
                         $this->uriBuilder->uriFor('index')
                 );


### PR DESCRIPTION
Current locallang reference in line 139 of ListModuleController is deprecated and produces following output in deprecation-logs of TYPO3 8.7.16 :
<Timestamp>: There is a reference to "EXT:lang/locallang_core.xlf", which has been moved to "EXT:lang/Resources/Private/Language/locallang_core.xlf". This fallback will be removed with TYPO3 v9.