### PR TITLE
Replace deprecated static extRelPath-call

### DIFF
--- a/Classes/Controller/ListModuleController.php
+++ b/Classes/Controller/ListModuleController.php
@@ -122,7 +122,7 @@ class ListModuleController extends ActionController
         }
         $pageRenderer = $view->getModuleTemplate()->getPageRenderer();
         $pageRenderer->addCssFile(
-                ExtensionManagementUtility::extRelPath('devlog') . 'Resources/Public/StyleSheet/Devlog.css'
+                ExtensionManagementUtility->siteRelPath('devlog') . 'Resources/Public/StyleSheet/Devlog.css'
         );
         $pageRenderer->loadRequireJsModule('TYPO3/CMS/Devlog/ListModule');
         $pageRenderer->addInlineSettingArray(


### PR DESCRIPTION
updated extRelPath-call due to deprecation. ("TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath() - since TYPO3 v8, will be removed in TYPO3 v9, use PathUtility::getAbsoluteWebPath(), or ->siteRelPath()")